### PR TITLE
De-duplicate X12 ST-AMT pathing for 850 and 860 data

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,0 +1,5 @@
+# Bots Grammars
+
+This support repository holds the grammars ported from SourceForge under the BOTS project, forked as BOTS-EDI.
+
+See [bots-edi](https://github.com/bots-edi/bots) for all of the details.

--- a/x12/3050/850003050.py
+++ b/x12/3050/850003050.py
@@ -192,8 +192,9 @@ structure = [
             {ID: 'LQ', MIN: 1, MAX: 99999},
         ]},
     ]},
-    {ID: 'CTT', MIN: 1, MAX: 1},
-    {ID: 'AMT', MIN: 0, MAX: 1},
+    {ID: 'CTT', MIN: 1, MAX: 1, LEVEL: [
+        {ID: 'AMT', MIN: 0, MAX: 1},
+    ]},
     {ID: 'SE', MIN: 1, MAX: 1},
 ]}
 ]

--- a/x12/3050/860003050.py
+++ b/x12/3050/860003050.py
@@ -188,8 +188,9 @@ structure = [
             {ID: 'LQ', MIN: 1, MAX: 99999},
         ]},
     ]},
-    {ID: 'CTT', MIN: 1, MAX: 1},
-    {ID: 'AMT', MIN: 0, MAX: 5},
+    {ID: 'CTT', MIN: 1, MAX: 1, LEVEL: [
+        {ID: 'AMT', MIN: 0, MAX: 5},
+    ]},
     {ID: 'SE', MIN: 1, MAX: 1},
 ]}
 ]


### PR DESCRIPTION
Modified 003050 grammars for 850 and 860 transactions to de-duplicate ST-AMT pathing and instead, nest the summary loop AMT segment as ST-CTT-AMT.